### PR TITLE
Add x86_64-linux to Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,6 +68,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-20
+  x86_64-linux
 
 DEPENDENCIES
   jekyll (~> 4.2.0)


### PR DESCRIPTION
Add x86_64-linux platform for DO App Platform builds (on heroku).